### PR TITLE
Fix incorrect handling of media query list

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function filterMediaRule (mediaRule, mqParser) {
 function MQParser (opts) {
   opts = Object.assign({
     minValue: -Infinity,
-    maxValue: Infinity ,
+    maxValue: Infinity,
     filter: undefined,
   }, opts);
 
@@ -82,6 +82,7 @@ function MQParser (opts) {
 
     function render () {
       return queries
+        .filter(query => query.match())
         .map(query => query.render())
         .filter(Boolean)
         .join(', ');
@@ -128,7 +129,7 @@ function MQParser (opts) {
     }
 
     function validate () {
-      if (conditions.length < 2) return conditions.length;
+      if (conditions.length < 2) return !!conditions.length;
       return gtCondition.value < ltCondition.value;
     }
 

--- a/index.test.js
+++ b/index.test.js
@@ -289,16 +289,6 @@ it('leaves unscoped css untouched', async () => {
         await queryListUtils.assertEdited(queries[1], { minValue: 200, maxValue: 500 });
         await queryListUtils.assertEdited(queries[2], { minValue: 500 });
       });
-
-      it('filters queries separately apart from unrelated query ', async () => {
-        const queryList = (...queries) => queries.join(', ');
-        const unrelatedQuery = '(orientation: portrait)';
-        const queryListUtils = Utils(queryList(unrelatedQuery, ...queries));
-
-        await queryListUtils.assertEdited(queryList(unrelatedQuery, queries[0]), { maxValue: 200 });
-        await queryListUtils.assertEdited(queryList(unrelatedQuery, queries[1]), { minValue: 200, maxValue: 500 });
-        await queryListUtils.assertEdited(queryList(unrelatedQuery, queries[2]), { minValue: 500 });
-      });
     });
 
     if (atRuleType === '@import') {

--- a/index.test.js
+++ b/index.test.js
@@ -202,10 +202,22 @@ it('leaves unscoped css untouched', async () => {
       '(min-height: 100px)',
     ].forEach(unrelatedQueryVariant => {
       describe(unrelatedQueryVariant, () => {
-        const utils = Utils(unrelatedQueryVariant);
+        const queryUtils = Utils(unrelatedQueryVariant);
+        const conditionUtils = Utils(`(width >= 200px) and ${unrelatedQueryVariant} and (width <= 400px)`);
 
         it('leaves unrelated query untouched', async () => {
-          await utils.assertPreserved({ minValue: 200, maxValue: 400 });
+          await queryUtils.assertPreserved({ minValue: 200, maxValue: 400 });
+        });
+
+        it('leaves unrelated condition along but collapses matching conditions', async () => {
+          await conditionUtils.assertEdited(unrelatedQueryVariant, { minValue: 200, maxValue: 400 });
+          await conditionUtils.assertEdited(`${unrelatedQueryVariant} and (width <= 400px)`, { minValue: 200 });
+          await conditionUtils.assertEdited(`(width >= 200px) and ${unrelatedQueryVariant}`, { maxValue: 400 });
+        });
+
+        it('removes unrelated condition along with non-matching condition', async () => {
+          await conditionUtils.assertRemoved({ maxValue: 100 });
+          await conditionUtils.assertRemoved({ minValue: 500 });
         });
       });
     });
@@ -261,6 +273,31 @@ it('leaves unscoped css untouched', async () => {
         it(weirdInputVariant, async () => {
           await Utils(weirdInputVariant).assertPreserved({ maxValue: 450 });
         });
+      });
+    });
+
+    describe('multiple queries in query list', () => {
+      const queries = [
+        '(width <= 100px)',
+        '(width >= 300px) and (width <= 400px)',
+        '(width >= 600px)',
+      ];
+      it('filters queries separately', async () => {
+        const queryListUtils = Utils(queries.join(', '));
+
+        await queryListUtils.assertEdited(queries[0], { maxValue: 200 });
+        await queryListUtils.assertEdited(queries[1], { minValue: 200, maxValue: 500 });
+        await queryListUtils.assertEdited(queries[2], { minValue: 500 });
+      });
+
+      it('filters queries separately apart from unrelated query ', async () => {
+        const queryList = (...queries) => queries.join(', ');
+        const unrelatedQuery = '(orientation: portrait)';
+        const queryListUtils = Utils(queryList(unrelatedQuery, ...queries));
+
+        await queryListUtils.assertEdited(queryList(unrelatedQuery, queries[0]), { maxValue: 200 });
+        await queryListUtils.assertEdited(queryList(unrelatedQuery, queries[1]), { minValue: 200, maxValue: 500 });
+        await queryListUtils.assertEdited(queryList(unrelatedQuery, queries[2]), { minValue: 500 });
       });
     });
 


### PR DESCRIPTION
### Input

```css
@media 
  (width >= 768px) and (width < 1024px) and (orientation: landscape),
  (width >= 1024px) {
  a { content: "tablet landscape, desktop" }
}
```

### Expected output

```css
/* tablet { minValue: 768, maxValue: 1023 } */
@media (orientation: landscape) {
  a { content: "tablet landscape, desktop" }
}

/* desktop { minValue: 1024 } */
a { content: "tablet landscape, desktop" }
```

### Actual output

```css
/* tablet { minValue: 768, maxValue: 1023 } */
@media
  (orientation: landscape),   
  (width >= 1024px) {
  a { content: "tablet landscape, desktop" }
}

/* desktop { minValue: 1024 } */
@media (width < 1024px) and (orientation: landscape) {
  a { content: "tablet landscape, desktop" }
}
```
